### PR TITLE
fix facebook deprecated requests for profile

### DIFF
--- a/src/Messenger.js
+++ b/src/Messenger.js
@@ -202,12 +202,12 @@ class Messenger extends EventEmitter {
       .then(res => this.constructor.handleError(res));
   }
 
-  getUser(id) {
+  getUser(id, fields) {
     if (!id) {
       throw new Error('A user ID is required.');
     }
-
-    const fields = [
+    
+    const fieldsArray = fields || [
       'first_name',
       'last_name',
       'profile_pic',
@@ -216,10 +216,12 @@ class Messenger extends EventEmitter {
       'gender',
       'is_payment_enabled',
       'last_ad_referral',
-    ].join();
+    ]
+    
+    const fieldsToRequest = fieldsArray.join();
 
     const url = this.buildURL(id, {
-      fields,
+      fieldsToRequest,
     });
 
     return this.get(url);


### PR DESCRIPTION
This is a fast PR because it is crashing when using the lib, facebook is saying about deprecated things

> 2018-11-13T19:58:19.125991+00:00 app[web.1]: (node:33) UnhandledPromiseRejectionWarning: Error: (#100) The last_ad_referral and is_payment_enabled fields are now deprecated. Please refer to our Developer Document for more info.